### PR TITLE
fix(provider): wrong initial state when disconnecting

### DIFF
--- a/packages/app/src/lib/store/persistantStore.ts
+++ b/packages/app/src/lib/store/persistantStore.ts
@@ -8,8 +8,14 @@ export function createPersistentStore<T>(key: string, initialState: T) {
 	/** Prefix {@link key} to easier keep track of them when debugging */
 	const storageKey = `ui-${key}`;
 
-	const getInitialState = (): T =>
-		JSON.parse((browser && localStorage.getItem(storageKey)) || JSON.stringify(initialState));
+	const getInitialState = (): T => {
+		if (browser) {
+			// Trust that we have manage to get the initial state from the provider
+			if (window.ethereum) return initialState;
+			else return JSON.parse(localStorage.getItem(storageKey) || JSON.stringify(initialState));
+		}
+		return initialState;
+	};
 
 	const state = writable(getInitialState());
 


### PR DESCRIPTION
When disconnecting outside the dApp and reloading the page the dApp would not realize that it was already disconnected.